### PR TITLE
Run the update script in the background

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 # Perform any database updates since the last deply.
 # --quick means "skip the five-second countdown".
-php /var/www/html/maintenance/update.php --quick
+php /var/www/html/maintenance/update.php --quick &
 
 docker-php-entrypoint apache2-foreground


### PR DESCRIPTION
This should hopefully fix the recurring 15-minute downtimes. The hypothesis is that DigitalOcean is re-spinning the VM and running the Dockerfile each time, and gets confused when the server isn't running immediately.